### PR TITLE
Refactor record not found detection in handlers

### DIFF
--- a/handlers.go
+++ b/handlers.go
@@ -1,11 +1,12 @@
 package main
 
 import (
+	"errors"
+	"net/http"
+
 	"github.com/google/uuid"
 	"github.com/jinzhu/gorm"
-
 	"github.com/labstack/echo/v4"
-	"net/http"
 )
 
 type handler struct {
@@ -43,7 +44,7 @@ func (h *handler) GetContact(c echo.Context) error {
 
 	var co contact
 	result := h.db.Where(&contact{ID: id}).First(&co)
-	if result.RecordNotFound() {
+	if errors.Is(result.Error, gorm.ErrRecordNotFound) {
 		return c.NoContent(http.StatusNotFound)
 	}
 	if result.Error != nil {
@@ -63,7 +64,7 @@ func (h *handler) UpdateContact(c echo.Context) error {
 
 	var co contact
 	result := h.db.Where(&contact{ID: id}).First(&co)
-	if result.RecordNotFound() {
+	if errors.Is(result.Error, gorm.ErrRecordNotFound) {
 		return c.NoContent(http.StatusNotFound)
 	}
 	if result.Error != nil {
@@ -87,7 +88,7 @@ func (h *handler) DeleteContact(c echo.Context) error {
 
 	var co contact
 	result := h.db.Where(&contact{ID: id}).First(&co)
-	if result.RecordNotFound() {
+	if errors.Is(result.Error, gorm.ErrRecordNotFound) {
 		return c.NoContent(http.StatusNotFound)
 	}
 	if result.Error != nil {

--- a/handlers_test.go
+++ b/handlers_test.go
@@ -1,7 +1,7 @@
 package main
 
 import (
-	"github.com/jinzhu/gorm"
+	"errors"
 	"io/ioutil"
 	"log"
 	"net/http"
@@ -10,6 +10,7 @@ import (
 	"testing"
 
 	"github.com/google/uuid"
+	"github.com/jinzhu/gorm"
 	"github.com/labstack/echo/v4"
 	"github.com/stretchr/testify/assert"
 )
@@ -84,8 +85,9 @@ func TestDeleteContact(t *testing.T) {
 		assert.Equal(t, http.StatusNoContent, rec.Code)
 
 		var co contact
-		mockDB.Where(&contact{ID: sample.ID}).First(&co)
-		assert.Equal(t, (contact{}), co)
+		result := mockDB.Where(&contact{ID: sample.ID}).First(&co)
+		assert.Error(t, result.Error)
+		assert.True(t, errors.Is(result.Error, gorm.ErrRecordNotFound))
 	}
 }
 


### PR DESCRIPTION
## Summary
- use errors.Is to check for gorm.ErrRecordNotFound instead of struct comparison
- update delete test to assert record-not-found via errors.Is

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_688fb5670110832397c708bd9d1663ec