### PR TITLE
Add validation to contact handlers

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/wastingnotime/contacts-backend-go-echo
 go 1.24
 
 require (
+	github.com/go-playground/validator/v10 v10.19.0
 	github.com/google/uuid v1.6.0
 	github.com/jinzhu/gorm v1.9.16
 	github.com/joho/godotenv v1.5.1
@@ -12,8 +13,12 @@ require (
 
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/gabriel-vasile/mimetype v1.4.3 // indirect
+	github.com/go-playground/locales v0.14.1 // indirect
+	github.com/go-playground/universal-translator v0.18.1 // indirect
 	github.com/jinzhu/inflection v1.0.0 // indirect
 	github.com/labstack/gommon v0.4.2 // indirect
+	github.com/leodido/go-urn v1.4.0 // indirect
 	github.com/mattn/go-colorable v0.1.14 // indirect
 	github.com/mattn/go-isatty v0.0.20 // indirect
 	github.com/mattn/go-sqlite3 v1.14.28 // indirect

--- a/go.sum
+++ b/go.sum
@@ -6,6 +6,16 @@ github.com/denisenkom/go-mssqldb v0.0.0-20191124224453-732737034ffd h1:83Wprp6RO
 github.com/denisenkom/go-mssqldb v0.0.0-20191124224453-732737034ffd/go.mod h1:xbL0rPBG9cCiLr28tMa8zpbdarY27NDyej4t/EjAShU=
 github.com/erikstmartin/go-testdb v0.0.0-20160219214506-8d10e4a1bae5 h1:Yzb9+7DPaBjB8zlTR87/ElzFsnQfuHnVUVqpZZIcV5Y=
 github.com/erikstmartin/go-testdb v0.0.0-20160219214506-8d10e4a1bae5/go.mod h1:a2zkGnVExMxdzMo3M0Hi/3sEU+cWnZpSni0O6/Yb/P0=
+github.com/gabriel-vasile/mimetype v1.4.3 h1:in2uUcidCuFcDKtdcBxlR0rJ1+fsokWf+uqxgUFjbI0=
+github.com/gabriel-vasile/mimetype v1.4.3/go.mod h1:d8uq/6HKRL6CGdk+aubisF/M5GcPfT7nKyLpA0lbSSk=
+github.com/go-playground/assert/v2 v2.2.0 h1:JvknZsQTYeFEAhQwI4qEt9cyV5ONwRHC+lYKSsYSR8s=
+github.com/go-playground/assert/v2 v2.2.0/go.mod h1:VDjEfimB/XKnb+ZQfWdccd7VUvScMdVu0Titje2rxJ4=
+github.com/go-playground/locales v0.14.1 h1:EWaQ/wswjilfKLTECiXz7Rh+3BjFhfDFKv/oXslEjJA=
+github.com/go-playground/locales v0.14.1/go.mod h1:hxrqLVvrK65+Rwrd5Fc6F2O76J/NuW9t0sjnWqG1slY=
+github.com/go-playground/universal-translator v0.18.1 h1:Bcnm0ZwsGyWbCzImXv+pAJnYK9S473LQFuzCbDbfSFY=
+github.com/go-playground/universal-translator v0.18.1/go.mod h1:xekY+UJKNuX9WP91TpwSH2VMlDf28Uj24BCp08ZFTUY=
+github.com/go-playground/validator/v10 v10.19.0 h1:ol+5Fu+cSq9JD7SoSqe04GMI92cbn0+wvQ3bZ8b/AU4=
+github.com/go-playground/validator/v10 v10.19.0/go.mod h1:dbuPbCMFw/DrkbEynArYaCwl3amGuJotoKCe95atGMM=
 github.com/go-sql-driver/mysql v1.5.0 h1:ozyZYNQW3x3HtqT1jira07DN2PArx2v7/mN66gGcHOs=
 github.com/go-sql-driver/mysql v1.5.0/go.mod h1:DCzpHaOWr8IXmIStZouvnhqoel9Qv2LBy8hT2VhHyBg=
 github.com/golang-sql/civil v0.0.0-20190719163853-cb61b32ac6fe h1:lXe2qZdvpiX5WZkZR4hgp4KJVfY3nMkvmwbVkpv1rVY=
@@ -24,6 +34,8 @@ github.com/labstack/echo/v4 v4.13.4 h1:oTZZW+T3s9gAu5L8vmzihV7/lkXGZuITzTQkTEhcX
 github.com/labstack/echo/v4 v4.13.4/go.mod h1:g63b33BZ5vZzcIUF8AtRH40DrTlXnx4UMC8rBdndmjQ=
 github.com/labstack/gommon v0.4.2 h1:F8qTUNXgG1+6WQmqoUWnz8WiEU60mXVVw0P4ht1WRA0=
 github.com/labstack/gommon v0.4.2/go.mod h1:QlUFxVM+SNXhDL/Z7YhocGIBYOiwB0mXm1+1bAPHPyU=
+github.com/leodido/go-urn v1.4.0 h1:WT9HwE9SGECu3lg4d/dIA+jxlljEa1/ffXKmRjqdmIQ=
+github.com/leodido/go-urn v1.4.0/go.mod h1:bvxc+MVxLKB4z00jd1z+Dvzr47oO32F/QSNjSBOlFxI=
 github.com/lib/pq v1.1.1 h1:sJZmqHoEaY7f+NPP8pgLB/WxulyR3fewgCM2qaSlBb4=
 github.com/lib/pq v1.1.1/go.mod h1:5WUZQaWbwv1U+lTReE5YruASi9Al49XbQIvNi/34Woo=
 github.com/mattn/go-colorable v0.1.14 h1:9A9LHSqF/7dyVVX6g0U9cwm9pG3kP9gSzcuIPHPsaIE=

--- a/handlers.go
+++ b/handlers.go
@@ -19,6 +19,10 @@ func (h *handler) CreateContact(c echo.Context) error {
 		return err
 	}
 
+	if err := c.Validate(payload); err != nil {
+		return c.JSON(http.StatusBadRequest, err.Error())
+	}
+
 	payload.ID = uuid.New().String()
 	result := h.db.Create(payload)
 	if result.Error != nil {
@@ -60,6 +64,10 @@ func (h *handler) UpdateContact(c echo.Context) error {
 	payload := new(contact)
 	if err := c.Bind(payload); err != nil {
 		return err
+	}
+
+	if err := c.Validate(payload); err != nil {
+		return c.JSON(http.StatusBadRequest, err.Error())
 	}
 
 	var co contact

--- a/handlers_test.go
+++ b/handlers_test.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/go-playground/validator/v10"
 	"github.com/google/uuid"
 	"github.com/jinzhu/gorm"
 	"github.com/labstack/echo/v4"
@@ -27,6 +28,7 @@ func TestMain(m *testing.M) {
 
 func TestCreateContact(t *testing.T) {
 	e := echo.New()
+	e.Validator = &CustomValidator{validator: validator.New()}
 	req := httptest.NewRequest(echo.POST, "/contacts", strings.NewReader(`{"firstName":"John","lastName":"Doe","phoneNumber":"1234567890"}`))
 	req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
 	rec := httptest.NewRecorder()
@@ -50,11 +52,26 @@ func TestCreateContact(t *testing.T) {
 	}
 }
 
+func TestCreateContactValidation(t *testing.T) {
+	e := echo.New()
+	e.Validator = &CustomValidator{validator: validator.New()}
+	req := httptest.NewRequest(echo.POST, "/contacts", strings.NewReader(`{"lastName":"Doe","phoneNumber":"1234567890"}`))
+	req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	h := &handler{mockDB}
+
+	if assert.NoError(t, h.CreateContact(c)) {
+		assert.Equal(t, http.StatusBadRequest, rec.Code)
+	}
+}
+
 func TestUpdateContact(t *testing.T) {
 	sample := contact{ID: uuid.New().String(), FirstName: "John", LastName: "Doe", PhoneNumber: "1234567890"}
 	mockDB.Create(sample)
 
 	e := echo.New()
+	e.Validator = &CustomValidator{validator: validator.New()}
 	req := httptest.NewRequest(echo.PUT, "/contacts/"+sample.ID, strings.NewReader(`{"firstName":"John1","lastName":"Doe1","phoneNumber":"12345678901"}`))
 	req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
 	rec := httptest.NewRecorder()
@@ -69,6 +86,31 @@ func TestUpdateContact(t *testing.T) {
 		assert.Equal(t, "John1", co.FirstName)
 		assert.Equal(t, "Doe1", co.LastName)
 		assert.Equal(t, "12345678901", co.PhoneNumber)
+
+		mockDB.Delete(&co)
+	}
+}
+
+func TestUpdateContactValidation(t *testing.T) {
+	sample := contact{ID: uuid.New().String(), FirstName: "John", LastName: "Doe", PhoneNumber: "1234567890"}
+	mockDB.Create(sample)
+
+	e := echo.New()
+	e.Validator = &CustomValidator{validator: validator.New()}
+	req := httptest.NewRequest(echo.PUT, "/contacts/"+sample.ID, strings.NewReader(`{"lastName":"Doe1","phoneNumber":"12345678901"}`))
+	req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	h := &handler{mockDB}
+
+	if assert.NoError(t, h.UpdateContact(c)) {
+		assert.Equal(t, http.StatusBadRequest, rec.Code)
+
+		var co contact
+		mockDB.Where(&contact{ID: sample.ID}).First(&co)
+		assert.Equal(t, "John", co.FirstName)
+		assert.Equal(t, "Doe", co.LastName)
+		assert.Equal(t, "1234567890", co.PhoneNumber)
 
 		mockDB.Delete(&co)
 	}

--- a/main.go
+++ b/main.go
@@ -1,11 +1,12 @@
 package main
 
 import (
-	"github.com/jinzhu/gorm"
-	_ "github.com/jinzhu/gorm/dialects/sqlite"
 	"log"
 	"os"
 
+	"github.com/go-playground/validator/v10"
+	"github.com/jinzhu/gorm"
+	_ "github.com/jinzhu/gorm/dialects/sqlite"
 	"github.com/joho/godotenv"
 	"github.com/labstack/echo/v4"
 	"github.com/labstack/echo/v4/middleware"
@@ -13,9 +14,17 @@ import (
 
 type contact struct {
 	ID          string `json:"id"`
-	FirstName   string `json:"firstName"`
-	LastName    string `json:"lastName"`
-	PhoneNumber string `json:"phoneNumber"`
+	FirstName   string `json:"firstName" validate:"required"`
+	LastName    string `json:"lastName" validate:"required"`
+	PhoneNumber string `json:"phoneNumber" validate:"required"`
+}
+
+type CustomValidator struct {
+	validator *validator.Validate
+}
+
+func (cv *CustomValidator) Validate(i interface{}) error {
+	return cv.validator.Struct(i)
 }
 
 func main() {
@@ -35,6 +44,7 @@ func main() {
 
 	//api --------
 	e := echo.New()
+	e.Validator = &CustomValidator{validator: validator.New()}
 
 	if environment == "development" {
 		e.Use(middleware.Logger())


### PR DESCRIPTION
## Summary
- require contact first name, last name and phone number using struct validation tags
- validate request payloads in `CreateContact` and `UpdateContact`
- register go-playground validator with Echo and add tests for validation failures

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68911a18ba4c83238090e8335c135b8d