### PR TITLE
refactor: move migrations to separate command

### DIFF
--- a/cmd/migrate/main.go
+++ b/cmd/migrate/main.go
@@ -1,0 +1,32 @@
+package main
+
+import (
+	"log"
+	"os"
+
+	"github.com/jinzhu/gorm"
+	_ "github.com/jinzhu/gorm/dialects/sqlite"
+	"github.com/joho/godotenv"
+)
+
+type contact struct {
+	ID          string
+	FirstName   string
+	LastName    string
+	PhoneNumber string
+}
+
+func main() {
+	godotenv.Load()
+	dbLocation := os.Getenv("DB_LOCATION")
+
+	db, err := gorm.Open("sqlite3", dbLocation)
+	if err != nil {
+		log.Panic(err)
+	}
+	defer db.Close()
+
+	db.AutoMigrate(&contact{})
+
+	log.Println("migrations applied")
+}

--- a/main.go
+++ b/main.go
@@ -40,8 +40,6 @@ func main() {
 	}
 	defer db.Close()
 
-	db.AutoMigrate(&contact{})
-
 	//api --------
 	e := echo.New()
 	e.Validator = &CustomValidator{validator: validator.New()}

--- a/readme.md
+++ b/readme.md
@@ -48,6 +48,11 @@ update deps
  go mod tidy
 ```
 
+run migrations
+```
+go run cmd/migrate
+```
+
 and then run the application
 ```
 go run .


### PR DESCRIPTION
## Summary
- remove automatic migration from server startup
- add standalone `cmd/migrate` command to apply database migrations
- document running migrations before starting the server

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6891fc277b1483239e8a23b4fba3ef9a